### PR TITLE
Fix tests by working around babel-plugin-transform-regenerator regression

### DIFF
--- a/test/charge-failed.js
+++ b/test/charge-failed.js
@@ -2,21 +2,21 @@ import test from 'ava'
 import { loadTemplate } from './_utils'
 
 test('expansion of meta', async t => {
-  const template = await loadTemplate('charge-failed.meta.hbs')
-  const metaString = template({
+  let template = await loadTemplate('charge-failed.meta.hbs')
+  let metaString = template({
     name: 'Exquisite Disaster',
     email: 'nunya@biznazz.yo',
     from: 'website@npmjs.com'
   })
-  const meta = JSON.parse(metaString)
+  let meta = JSON.parse(metaString)
   t.is(meta.subject, 'npm, Inc.: charge failed')
   t.is(meta.to, '"Exquisite Disaster" <nunya@biznazz.yo>')
   t.is(meta.from, '"npm, Inc." <website@npmjs.com>')
 })
 
 test('expansion of text', async t => {
-  const template = await loadTemplate('charge-failed.text.hbs')
-  const text = template({
+  let template = await loadTemplate('charge-failed.text.hbs')
+  let text = template({
     amount: '$700.00',
     card: '9876',
     support_email: 'support@npmjs.com'

--- a/test/confirm-email-change.js
+++ b/test/confirm-email-change.js
@@ -13,13 +13,13 @@ test.after(t => {
 })
 
 test('expansion of meta', async t => {
-  const template = await loadTemplate('confirm-email-change.meta.hbs')
-  const metaString = template({
+  let template = await loadTemplate('confirm-email-change.meta.hbs')
+  let metaString = template({
     name: 'Exquisite Disaster',
     changeEmailTo: 'nunya@biznazz.yo',
     from: 'website@npmjs.com'
   })
-  const meta = JSON.parse(metaString)
+  let meta = JSON.parse(metaString)
   t.is(meta.subject, 'Please confirm your new npm email')
   t.is(meta.to, '"Exquisite Disaster" <nunya@biznazz.yo>')
   t.is(meta.from, '"npm, Inc." <website@npmjs.com>')
@@ -27,8 +27,8 @@ test('expansion of meta', async t => {
 })
 
 test('expansion of text', async t => {
-  const template = await loadTemplate('confirm-email-change.text.hbs')
-  const text = template({
+  let template = await loadTemplate('confirm-email-change.text.hbs')
+  let text = template({
     name: 'fidget',
     changeEmailFrom: 'hello.fidget@gmail.co',
     changeEmailTo: 'f@idg.et',

--- a/test/confirm-user-email.js
+++ b/test/confirm-user-email.js
@@ -13,13 +13,13 @@ test.after(t => {
 })
 
 test('expansion of meta', async t => {
-  const template = await loadTemplate('confirm-user-email.meta.hbs')
-  const metaString = template({
+  let template = await loadTemplate('confirm-user-email.meta.hbs')
+  let metaString = template({
     name: 'Exquisite Disaster',
     email: 'nunya@biznazz.yo',
     from: 'website@npmjs.com'
   })
-  const meta = JSON.parse(metaString)
+  let meta = JSON.parse(metaString)
   t.is(meta.subject, 'Welcome to npm! Please confirm your email address')
   t.is(meta.to, '"Exquisite Disaster" <nunya@biznazz.yo>')
   t.is(meta.from, '"npm, Inc." <website@npmjs.com>')
@@ -27,8 +27,8 @@ test('expansion of meta', async t => {
 })
 
 test('expansion of text', async t => {
-  const template = await loadTemplate('confirm-user-email.text.hbs')
-  const text = template({
+  let template = await loadTemplate('confirm-user-email.text.hbs')
+  let text = template({
     name: 'fidget',
     host: 'https://www.npmjs.com',
     support_email: 'support@npmjs.com'

--- a/test/contact-support.js
+++ b/test/contact-support.js
@@ -2,21 +2,21 @@ import test from 'ava'
 import { loadTemplate } from './_utils'
 
 test('expansion of meta', async t => {
-  const template = await loadTemplate('contact-support.meta.hbs')
-  const metaString = template({
+  let template = await loadTemplate('contact-support.meta.hbs')
+  let metaString = template({
     subject: 'Pick a subject. Any subject.',
     email: 'nunya@biznazz.yo',
     from: 'website@npmjs.com'
   })
-  const meta = JSON.parse(metaString)
+  let meta = JSON.parse(metaString)
   t.is(meta.subject, 'Pick a subject. Any subject.')
   t.is(meta.to, 'nunya@biznazz.yo')
   t.is(meta.from, '"npm, Inc. Support" <support@npmjs.com>')
 })
 
 test('expansion of text', async t => {
-  const template = await loadTemplate('contact-support.text.hbs')
-  const text = template({
+  let template = await loadTemplate('contact-support.text.hbs')
+  let text = template({
     name: 'Fundip Stick',
     email: 'jiminy@cricket.xyz',
     message: 'Uhh, this is a weird template.'

--- a/test/disclosure.js
+++ b/test/disclosure.js
@@ -2,22 +2,22 @@ import test from 'ava'
 import { loadTemplate } from './_utils'
 
 test('expansion of meta', async t => {
-  const template = await loadTemplate('disclosure.meta.hbs')
-  const metaString = template({
+  let template = await loadTemplate('disclosure.meta.hbs')
+  let metaString = template({
     name: 'Exquisite Disaster',
     email: 'nunya@biznazz.yo',
     from: 'security@npmjs.com',
     disclosure_subject: 'I need to disclose something'
   })
-  const meta = JSON.parse(metaString)
+  let meta = JSON.parse(metaString)
   t.is(meta.subject, 'I need to disclose something')
   t.is(meta.to, '"Exquisite Disaster" <nunya@biznazz.yo>')
   t.is(meta.from, '"npm, Inc. Security" <security@npmjs.com>')
 })
 
 test('expansion of text', async t => {
-  const template = await loadTemplate('disclosure.text.hbs')
-  const text = template({
+  let template = await loadTemplate('disclosure.text.hbs')
+  let text = template({
     disclosure_message: 'Something went wrong, but we\'re gonna fix it.'
   })
   t.ok(text.match(/Something went wrong, but we're gonna fix it\./))

--- a/test/enterprise-confirm-email.js
+++ b/test/enterprise-confirm-email.js
@@ -2,20 +2,20 @@ import test from 'ava'
 import { loadTemplate } from './_utils'
 
 test('expansion of meta', async t => {
-  const template = await loadTemplate('enterprise-confirm-email.meta.hbs')
-  const metaString = template({
+  let template = await loadTemplate('enterprise-confirm-email.meta.hbs')
+  let metaString = template({
     email: 'nunya@biznazz.yo',
     from: 'website@npmjs.com'
   })
-  const meta = JSON.parse(metaString)
+  let meta = JSON.parse(metaString)
   t.is(meta.subject, 'Welcome to npm On-Site! Please verify your email address')
   t.is(meta.to, '"nunya@biznazz.yo" <nunya@biznazz.yo>')
   t.is(meta.from, '"npm, Inc." <website@npmjs.com>')
 })
 
 test('expansion of text', async t => {
-  const template = await loadTemplate('enterprise-confirm-email.text.hbs')
-  const text = template({
+  let template = await loadTemplate('enterprise-confirm-email.text.hbs')
+  let text = template({
     host: 'https://www.npmjs.com',
     email: 'jiminy@cricket.xyz',
     verification_key: '00000000-0000-0000-0000-000000000000',

--- a/test/enterprise-send-license.js
+++ b/test/enterprise-send-license.js
@@ -2,21 +2,21 @@ import test from 'ava'
 import { loadTemplate } from './_utils'
 
 test('expansion of meta', async t => {
-  const template = await loadTemplate('enterprise-send-license.meta.hbs')
-  const metaString = template({
+  let template = await loadTemplate('enterprise-send-license.meta.hbs')
+  let metaString = template({
     name: 'Exquisite Disaster',
     email: 'nunya@biznazz.yo',
     from: 'website@npmjs.com'
   })
-  const meta = JSON.parse(metaString)
+  let meta = JSON.parse(metaString)
   t.is(meta.subject, 'Your npm On-Site license')
   t.is(meta.to, '"Exquisite Disaster" <nunya@biznazz.yo>')
   t.is(meta.from, '"npm, Inc." <website@npmjs.com>')
 })
 
 test('expansion of text', async t => {
-  const template = await loadTemplate('enterprise-send-license.text.hbs')
-  const text = template({
+  let template = await loadTemplate('enterprise-send-license.text.hbs')
+  let text = template({
     name: 'Fundip Stick',
     email: 'jiminy@cricket.xyz',
     license_key: '00000000-0000-0000-0000-000000000000',

--- a/test/enterprise-verification.js
+++ b/test/enterprise-verification.js
@@ -2,21 +2,21 @@ import test from 'ava'
 import { loadTemplate } from './_utils'
 
 test('expansion of meta', async t => {
-  const template = await loadTemplate('enterprise-verification.meta.hbs')
-  const metaString = template({
+  let template = await loadTemplate('enterprise-verification.meta.hbs')
+  let metaString = template({
     name: 'Exquisite Disaster',
     email: 'nunya@biznazz.yo',
     from: 'website@npmjs.com'
   })
-  const meta = JSON.parse(metaString)
+  let meta = JSON.parse(metaString)
   t.is(meta.subject, 'Your npm On-Site trial license key and instructions')
   t.is(meta.to, '"Exquisite Disaster" <nunya@biznazz.yo>')
   t.is(meta.from, '"npm, Inc." <website@npmjs.com>')
 })
 
 test('expansion of text', async t => {
-  const template = await loadTemplate('enterprise-verification.text.hbs')
-  const text = template({
+  let template = await loadTemplate('enterprise-verification.text.hbs')
+  let text = template({
     name: 'Fundip Stick',
     email: 'jiminy@cricket.xyz',
     license_key: '00000000-0000-0000-0000-000000000000',

--- a/test/forgot-password.js
+++ b/test/forgot-password.js
@@ -13,13 +13,13 @@ test.after(t => {
 })
 
 test('expansion of meta', async t => {
-  const template = await loadTemplate('forgot-password.meta.hbs')
-  const metaString = template({
+  let template = await loadTemplate('forgot-password.meta.hbs')
+  let metaString = template({
     name: 'Exquisite Disaster',
     email: 'nunya@biznazz.yo',
     from: 'support@npmjs.com'
   })
-  const meta = JSON.parse(metaString)
+  let meta = JSON.parse(metaString)
   t.is(meta.subject, 'Your npm password reset')
   t.is(meta.to, '"Exquisite Disaster" <nunya@biznazz.yo>')
   t.is(meta.from, '"npm, Inc. support" <support@npmjs.com>')
@@ -27,8 +27,8 @@ test('expansion of meta', async t => {
 })
 
 test('expansion of text', async t => {
-  const template = await loadTemplate('forgot-password.text.hbs')
-  const text = template({
+  let template = await loadTemplate('forgot-password.text.hbs')
+  let text = template({
     name: 'fidget',
     host: 'https://www.npmjs.com',
     support_email: 'support@npmjs.com'

--- a/test/npme-trial-verification.js
+++ b/test/npme-trial-verification.js
@@ -2,21 +2,21 @@ import test from 'ava'
 import { loadTemplate } from './_utils'
 
 test('expansion of meta', async t => {
-  const template = await loadTemplate('npme-trial-verification.meta.hbs')
-  const metaString = template({
+  let template = await loadTemplate('npme-trial-verification.meta.hbs')
+  let metaString = template({
     name: 'Exquisite Disaster',
     email: 'nunya@biznazz.yo',
     from: 'website@npmjs.com'
   })
-  const meta = JSON.parse(metaString)
+  let meta = JSON.parse(metaString)
   t.is(meta.subject, 'Welcome to npm On-Site! Please verify your email address')
   t.is(meta.to, '"Exquisite Disaster" <nunya@biznazz.yo>')
   t.is(meta.from, '"npm, Inc." <website@npmjs.com>')
 })
 
 test('expansion of text', async t => {
-  const template = await loadTemplate('npme-trial-verification.text.hbs')
-  const text = template({
+  let template = await loadTemplate('npme-trial-verification.text.hbs')
+  let text = template({
     name: 'Fundip Stick',
     host: 'https://www.npmjs.com',
     verification_key: '00000000-0000-0000-0000-000000000000'

--- a/test/revert-email-change.js
+++ b/test/revert-email-change.js
@@ -13,13 +13,13 @@ test.after(t => {
 })
 
 test('expansion of meta', async t => {
-  const template = await loadTemplate('revert-email-change.meta.hbs')
-  const metaString = template({
+  let template = await loadTemplate('revert-email-change.meta.hbs')
+  let metaString = template({
     name: 'Exquisite Disaster',
     changeEmailFrom: 'nunya@biznazz.yo',
     from: 'support@npmjs.com'
   })
-  const meta = JSON.parse(metaString)
+  let meta = JSON.parse(metaString)
   t.is(meta.subject, 'Your npm email change')
   t.is(meta.to, '"Exquisite Disaster" <nunya@biznazz.yo>')
   t.is(meta.from, '"npm, Inc. support" <support@npmjs.com>')
@@ -27,8 +27,8 @@ test('expansion of meta', async t => {
 })
 
 test('expansion of text', async t => {
-  const template = await loadTemplate('revert-email-change.text.hbs')
-  const text = template({
+  let template = await loadTemplate('revert-email-change.text.hbs')
+  let text = template({
     name: 'fidget',
     changeEmailFrom: 'hello.fidget@gmail.co',
     changeEmailTo: 'f@idg.et',


### PR DESCRIPTION
[Tests passed](https://travis-ci.org/npm/email-templates/jobs/102221573) before merge, [then failed](https://travis-ci.org/npm/email-templates/jobs/102348734) after merge with exact same code. Found the problem to be related to the `babel-plugin-transform-regenerator` transitive dependency used by `ava`.

Workaround is to change `const` to `let` within `async` functions.

See sindresorhus/ava#425.