### PR TITLE
Add build status badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # npm-email-templates
 
+[![build status](https://img.shields.io/travis/npm/email-templates.svg)](https://travis-ci.org/npm/email-templates)
+
 shared templates for transactional npm emails.
 
 adding html-email templates for Eloqua integration; css could be cleaned up/consolidated.


### PR DESCRIPTION
Now that this repo has unit tests, would be nice to quickly see the build status on the README.