### PR TITLE
Replace shields.io badge with one from Travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # npm-email-templates
 
-[![build status](https://img.shields.io/travis/npm/email-templates.svg)](https://travis-ci.org/npm/email-templates)
+[![build status](https://travis-ci.org/npm/email-templates.svg)](https://travis-ci.org/npm/email-templates)
 
 shared templates for transactional npm emails.
 


### PR DESCRIPTION
Apparently shields.io is not as reliable as it once was.