### PR TITLE
Drop subject from contact-support meta template to avoid unwanted escaping

### DIFF
--- a/contact-support.meta.hbs
+++ b/contact-support.meta.hbs
@@ -1,5 +1,4 @@
 {
-  "subject": "{{subject}}",
   "to": "{{email}}",
   "from": "\"npm, Inc. Support\" <support@npmjs.com>"
 }

--- a/test/contact-support.js
+++ b/test/contact-support.js
@@ -4,12 +4,10 @@ import { loadTemplate } from './_utils'
 test('expansion of meta', async t => {
   let template = await loadTemplate('contact-support.meta.hbs')
   let metaString = template({
-    subject: 'Pick a subject. Any subject.',
     email: 'nunya@biznazz.yo',
     from: 'website@npmjs.com'
   })
   let meta = JSON.parse(metaString)
-  t.is(meta.subject, 'Pick a subject. Any subject.')
   t.is(meta.to, 'nunya@biznazz.yo')
   t.is(meta.from, '"npm, Inc. Support" <support@npmjs.com>')
 })


### PR DESCRIPTION
This is needed before `newww` can bump its `mustache-mailer` dependency, which will stop ignoring the `"subject"` field in `contact-support.meta.hbs`.

The current problem is `newww` passes an object like this to the template:

```js
var mail = {
  to: recipient,
  subject: data.subject + " - FROM: " + '"' + data.name + '" <' + data.email + '>',
  text: data.message
};
```

Which, when the expanded meta template value is used results in something like:

```
Hi! - FROM: &quot;Boom&quot; &lt;boom@bam.com&gt;
```

Instead of the intended:

```
Hi! - FROM: "Boom" <boom@bam.com>
```

If we attempt to fix the HTML escaping with the triple-stache operator in the template:

```hbs
{
  "subject": "{{{subject}}}",
  "to": "{{email}}",
  "from": "\"npm, Inc. Support\" <support@npmjs.com>"
}
```

Then the result is invalid JSON (because the double quotes need to be escaped).

Therefore, the simplest solution is to remove the `"subject"` from the template altogether and use whatever `data` value is given as is.